### PR TITLE
build: move flake-utils from semnix to numtide

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -21,15 +21,15 @@
         "systems": "systems"
       },
       "locked": {
-        "lastModified": 1701680307,
-        "narHash": "sha256-kAuep2h5ajznlPMD9rnQyffWG8EM/C73lejGofXvdM8=",
-        "owner": "semnix",
+        "lastModified": 1710146030,
+        "narHash": "sha256-SZ5L6eA7HJ/nmkzGG7/ISclqe6oZdOZTNoesiInkXPQ=",
+        "owner": "numtide",
         "repo": "flake-utils",
-        "rev": "4022d587cbbfd70fe950c1e2083a02621806a725",
+        "rev": "b1d9ab70662946ef0850d488da1c9019f3a9752a",
         "type": "github"
       },
       "original": {
-        "owner": "semnix",
+        "owner": "numtide",
         "repo": "flake-utils",
         "type": "github"
       }

--- a/flake.nix
+++ b/flake.nix
@@ -11,7 +11,7 @@
     };
 
     flake-utils = {
-      url = "github:semnix/flake-utils";
+      url = "github:numtide/flake-utils";
     };
 
     naersk = {


### PR DESCRIPTION
Signed-off-by: Christina Sørensen <christina@cafkafk.com>
