### PR TITLE
Remove print 1 for --short

### DIFF
--- a/src/fortune.rs
+++ b/src/fortune.rs
@@ -98,7 +98,6 @@ pub fn get_quote(quote_size: &u8) {
             if target_length < 1 {
                 target_length = 1;
             }
-            println!("{n}");
             for q in &quotes {
                 if q.len() <= target_length {
                     tmp.push(q)


### PR DESCRIPTION
Do not print number 1 when running with '--short'.

Fixes #78
