### PR TITLE
feat: add equal option to ignore length when selecting files

### DIFF
--- a/README.md
+++ b/README.md
@@ -104,3 +104,6 @@ topic of discussion, the final say rests with cafkafk's judgment.
 
 For more info about contributing and the acceptance policy, please see
 [EDITORIAL.md](https://github.com/cafkafk/fortune-kind/blob/main/EDITORIAL.md)
+
+### Miscellany
+If you're seeing � symbols in your fortunes, try replacing indent characters with four spaces, and substituting any special characters for utf8 encodable versions. This shouldn't happen with the default fortunes included in this repo.

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -3,7 +3,7 @@
 //
 // SPDX-License-Identifier: AGPL-3.0-only
 
-use clap::{arg, command, crate_authors, Arg, Command};
+use clap::{arg, command, crate_authors, Arg, ArgAction, Command};
 
 pub fn build_cli() -> Command {
     command!()
@@ -34,5 +34,18 @@ pub fn build_cli() -> Command {
                 .long("length")
                 .help("Finds a fortune that is shorter than provided number."),
         )
+        // .arg(
+        //     Arg::new("short")
+        //         .short('s')
+        //         .long("short")
+        //         .help("Shows a short aporism."),
+        // )
         .arg(arg!(-s --short ... "Shows a short aporism."))
+        .arg(
+            Arg::new("equal")
+                .short('e')
+                .long("equal")
+                .action(ArgAction::SetTrue)
+                .help("Consider all fortune files to be of equal size."),
+        )
 }

--- a/src/fortune.rs
+++ b/src/fortune.rs
@@ -62,6 +62,7 @@ pub fn search_fortunes(pattern: &str) {
 ///   - `2-254`: Reduces the target length by half for each increment.
 ///   - `255`: Prints a humorous message and exits.
 ///   - `0` or any other value: Retrieves a completely random quote.
+/// * `equal` - Uses `get_random_file_unweighted` to fetch a qoute, pretending all files are the same size
 ///
 /// # Panics
 ///
@@ -75,9 +76,14 @@ pub fn search_fortunes(pattern: &str) {
 /// get_quote(&1); // Retrieves a quote of default size.
 /// get_quote(&255); // Prints a humorous message and exits.
 /// ```
-pub fn get_quote(quote_size: &u8) {
-    //let file = handle_file_errors(fortune_dir, &file::pick_file);
-    let file = &random::get_random_file_weighted(PathBuf::from(get_fortune_dir())).unwrap();
+pub fn get_quote(quote_size: &u8, is_equal: bool) {
+    // let file = handle_file_errors(fortune_dir, &file::pick_file);
+    let file = if is_equal {
+        random::get_random_file_unweighted(PathBuf::from(get_fortune_dir()))
+    } else {
+        random::get_random_file_weighted(PathBuf::from(get_fortune_dir()))
+    }
+    .unwrap();
 
     let quotes: Vec<&str> = file.split("\n%\n").collect();
 

--- a/src/fortune.rs
+++ b/src/fortune.rs
@@ -112,7 +112,7 @@ pub fn get_quote(quote_size: &u8, is_equal: bool) {
             println!("{}", tmp[random::random(tmp.len())]);
         }
         _ => {
-            println!("{}", quotes[random::random(quotes.len() - 1)]);
+            println!("{}", quotes[random::random(quotes.len())]);
         }
     }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -13,12 +13,15 @@ mod random;
 fn main() -> io::Result<()> {
     let matches = cli::build_cli().get_matches();
 
+    // Could be collapsed a little more, but leaving expanded for readability
     if let Some(pattern) = matches.get_one::<String>("find") {
         fortune::search_fortunes(pattern);
     } else if let Some(short) = matches.get_one::<u8>("short") {
-        fortune::get_quote(short);
+        fortune::get_quote(short, matches.get_flag("equal"));
+    } else if matches.get_flag("equal") {
+        fortune::get_quote(&0, true);
     } else {
-        fortune::get_quote(&0);
+        fortune::get_quote(&0, false);
     }
 
     Ok(())

--- a/src/random.rs
+++ b/src/random.rs
@@ -41,6 +41,11 @@ pub fn get_random_file_weighted(path: PathBuf) -> std::io::Result<String> {
     let mut rng = thread_rng();
     match get_file_sizes(&path) {
         Ok(mut files) => {
+            if files.is_empty() {
+                eprintln!("No fortune files found in {path:?}");
+                std::process::exit(1);
+            }
+
             files.sort_unstable_by(|a, b| a.0.partial_cmp(&b.0).unwrap());
             let mut contents = String::new();
             std::fs::File::open(&files.choose_weighted(&mut rng, |item| item.0).unwrap().1)?
@@ -65,6 +70,11 @@ pub fn get_random_file_unweighted(path: PathBuf) -> std::io::Result<String> {
     match get_file_sizes(&path) {
         Ok(files) => {
             let mut contents = String::new();
+            if files.is_empty() {
+                eprintln!("No fortune files found in {path:?}");
+                std::process::exit(1);
+            }
+
             std::fs::File::open(&files.choose(&mut rng).unwrap().1)?
                 .read_to_string(&mut contents)?;
             Ok(contents)

--- a/src/random.rs
+++ b/src/random.rs
@@ -58,6 +58,28 @@ pub fn get_random_file_weighted(path: PathBuf) -> std::io::Result<String> {
     }
 }
 
+pub fn get_random_file_unweighted(path: PathBuf) -> std::io::Result<String> {
+    use std::io::ErrorKind;
+
+    let mut rng = thread_rng();
+    match get_file_sizes(&path) {
+        Ok(files) => {
+            let mut contents = String::new();
+            std::fs::File::open(&files.choose(&mut rng).unwrap().1)?
+                .read_to_string(&mut contents)?;
+            Ok(contents)
+        }
+        Err(e) => match e.kind() {
+            ErrorKind::NotFound => {
+                eprintln!("{e}");
+                println!("Couldn't find \"{path:?}\", make sure you set FORTUNE_DIR correctly, or verify that you're in a directory with a folder named \"{path:?}\".",);
+                std::process::exit(1);
+            }
+            _ => panic!("Error: {}", e),
+        },
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/src/random.rs
+++ b/src/random.rs
@@ -45,13 +45,14 @@ pub fn get_random_file_weighted(path: PathBuf) -> std::io::Result<String> {
                 eprintln!("No fortune files found in {path:?}");
                 std::process::exit(1);
             }
-
             files.sort_unstable_by(|a, b| a.0.partial_cmp(&b.0).unwrap());
-            let mut contents = String::new();
+            let mut contents: Vec<u8> = Vec::new();
+
             std::fs::File::open(&files.choose_weighted(&mut rng, |item| item.0).unwrap().1)?
-                .read_to_string(&mut contents)?;
-            Ok(contents)
+                .read_to_end(&mut contents)?;
+            Ok(String::from_utf8_lossy(&contents).into_owned())
         }
+
         Err(e) => match e.kind() {
             ErrorKind::NotFound => {
                 eprintln!("{e}");
@@ -69,16 +70,17 @@ pub fn get_random_file_unweighted(path: PathBuf) -> std::io::Result<String> {
     let mut rng = thread_rng();
     match get_file_sizes(&path) {
         Ok(files) => {
-            let mut contents = String::new();
             if files.is_empty() {
                 eprintln!("No fortune files found in {path:?}");
                 std::process::exit(1);
             }
+            let mut contents: Vec<u8> = Vec::new();
 
             std::fs::File::open(&files.choose(&mut rng).unwrap().1)?
-                .read_to_string(&mut contents)?;
-            Ok(contents)
+                .read_to_end(&mut contents)?;
+            Ok(String::from_utf8_lossy(&contents).into_owned())
         }
+
         Err(e) => match e.kind() {
             ErrorKind::NotFound => {
                 eprintln!("{e}");


### PR DESCRIPTION
This behaviour was originally the default, then was changed in 8b3cd1e. This adds it back optionally, and is disabled by default.
Looks like the man page was successfully generated with `clap`, but I'm not sure how to do the licensing/crediting part.

## Changelog Entry

### Added

- Add `--equal` option to ignore file length

### Additional Information

Originally, files were treted the same irregardless of length. This was changed in [8b3cd1e](https://github.com/cafkafk/fortune-kind/commit/8b3cd1e9ac061ce2db8d4c5bf69b0e6ca69cec15). This PR doesn't change the default behaviour, but adds a flag that enables treating all files as equal.

---

### Automated Checks

- [x] **Nix Build:** Ran `nix build` and verified the `./result` symlink was created successfully.
- [x] **Unit Tests:** Ran `cargo test` (or `nix build .#test`) and all tests passed.
- [x] **Linting:** Ran `cargo clippy` and ensured no warnings were introduced.
- [x] **Formatting:** Ran `cargo fmt` to ensure code style consistency.
- [x] **License Compliance:** Ran `reuse lint` to verify copyright and license headers.

### Manual Verification

- [x] **Binary Run:** Ran the binary (e.g., `./result/bin/fortune-kind`) and verified basic functionality.
- [ ] **Cross-Platform:** Verified (if applicable) that paths/env vars work on the target system.

### Build Platform

- [x] x86_64-linux

---

## Pre-Submission Checklist

**Before submitting, please ensure the following:**

- [x] **Target Branch:** My pull request targets the `main` branch.
- [x] **Self-Review:** I have performed a self-review of my code.
- [x] **Documentation:** I have updated relevant documentation (README, manpages, or `EDITORIAL.md`) if necessary.
- [ ] **Dependencies:** I have updated `Cargo.toml` and `flake.nix` if I added new dependencies.
- [x] **Commit Messages:** My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) so `git-cliff` can auto-generate the changelog.